### PR TITLE
Fix compilation commands in README and add more explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # berke1337_re
 Reverse engineering challenges for berke1337.
 
-`git clone git@github.com:nigel/berke1337_re.git`
+`git clone https://github.com/nigel/berke1337_re.git`
 
 
 ## How to run the programs 
@@ -9,8 +9,8 @@ Reverse engineering challenges for berke1337.
 - Run `docker build -t re https://github.com/nigel/berke1337_re.git`
 - Run `docker run -it re` to run the programs!
 
-- **If you have `gcc` installed on your computer**, you won't need docker. Just run `gcc chal1.c -fno-stack-protection -g` to compile your own programs.
-- **If you're running linux**, you can just run these programs directly.
+- **If you have `gcc` installed on your computer**, you won't need docker. Instead, you can compile the programs yourself. For example, to run `chal1.c`, do `cd src` and then `gcc chal1.c -fno-stack-protector -g -o chal1` to compile the `chal1.c` C program into an executable `chal1`.
+- **If you're running Linux**, you can just run these programs directly.
 - **Optionally,** you can SSH into [EECS Instructional accounts](https://acropolis.cs.berkeley.edu/~account/webacct/) and run the programs there. (Not tested).
 
 


### PR DESCRIPTION
The `gcc` flag should be `-fno-stack-protector`, not `-fno-stack-protection`. I also add a bit more clear instructions and replaced the `git clone` command with a version that should work for people who don't have access to your Github account (lol)